### PR TITLE
Create webhook handler for Shippo's track_updated event

### DIFF
--- a/server/src/api/shippohooks/handle-shippo-track-updated.test.ts
+++ b/server/src/api/shippohooks/handle-shippo-track-updated.test.ts
@@ -1,0 +1,83 @@
+import { DateTime } from 'luxon'
+import { app } from 'src/app'
+import { Order, User } from 'src/models'
+import { cleanUpDB, dropAllCollections } from 'src/test-utils/db'
+import { OrderState } from 'src/util/enums'
+import * as Slack from 'src/util/slack'
+import { stripe } from 'src/util/stripe'
+import { createMockOrder } from 'src/__mocks__/models/Order'
+import { createMockUser } from 'src/__mocks__/models/User'
+import request from 'supertest'
+
+jest.mock('src/util/shipment')
+jest.mock('src/util/slack')
+
+// NOTE: No need to initDB in this test bc the src/app import initializes it
+afterAll(async () => {
+  await cleanUpDB()
+})
+
+afterEach(async () => {
+  await dropAllCollections()
+})
+
+describe('HandleShippoTrackUpdated Shippo webhook handler', () => {
+  let requestingUser: User
+  let agent: request.SuperAgentTest
+
+  beforeEach(async (done) => {
+    // Create a user and log in using an agent that the it() blocks will also use
+    // in order to preserve access token cookie
+    requestingUser = await createMockUser({
+      password: 'foobar',
+    })
+    agent = request.agent(app)
+    await agent.post('/auth/login').send({
+      email: requestingUser.email,
+      password: 'foobar',
+    })
+
+    jest.spyOn(stripe.webhooks, 'constructEvent').mockImplementation((e: any) => e)
+    done()
+  })
+
+  it('updates the order tracking status/eta, sends email if needed, and posts a Slack message', async () => {
+    const order = await createMockOrder({
+      state: OrderState.Captured,
+      shippoTransactionId: 'transaction_id',
+    })
+
+    const mockEventData = {
+      /* eslint-disable camelcase */
+      transaction: 'transaction_id',
+      tracking_status: {
+        status: 'TRANSIT',
+        substatus: 'out_for_delivery',
+      },
+      eta: DateTime.now().plus({ days: 7 }).toISOTime(),
+      /* eslint-enable camelcase */
+    }
+
+    const slackSpy = jest.spyOn(Slack, 'postSimpleMarkdownMessage').mockResolvedValue(null)
+
+    await agent
+      .post('/api/shippohooks')
+      .send({
+        event: 'track_updated',
+        data: mockEventData,
+      })
+      .set('Accept', 'application/json')
+      .expect(200)
+
+    const updatedOrder = await Order.mongo.findById(order.id)
+
+    expect(updatedOrder.lastShippoTrackingStatus).toMatchObject(mockEventData.tracking_status)
+    expect(updatedOrder.shipmentEta).toBe(mockEventData.eta)
+    expect(updatedOrder.notifiedShipped).toBe(true)
+
+    expect(slackSpy).toHaveBeenCalledWith({
+      channel: Slack.Channel.Orders,
+      text: expect.stringContaining('Status: TRANSIT'),
+    })
+  })
+})

--- a/server/src/api/shippohooks/handle-shippo-track-updated.ts
+++ b/server/src/api/shippohooks/handle-shippo-track-updated.ts
@@ -34,6 +34,7 @@ export default async (message: any) => {
   // - RETURNED: The package is en route to be returned to the sender, or has been returned successfully.
   // - FAILURE: The carrier indicated that there has been an issue with the delivery. This can happen for various reasons and depends on the carrier. This status does not indicate a technical, but a delivery issue.
   // - UNKNOWN: The package has not been found via the carrier’s tracking system.
+  // See https://goshippo.com/docs/tracking/#event-definitions for more details
   if (trackingStatus.status === 'TRANSIT') {
     await order.sendShippedEmailIfNeeded({
       eta: shipmentEta,

--- a/server/src/api/shippohooks/handle-shippo-track-updated.ts
+++ b/server/src/api/shippohooks/handle-shippo-track-updated.ts
@@ -1,0 +1,57 @@
+import { Order, User } from 'src/models'
+import { formatName } from 'src/util/name'
+import * as Slack from 'src/util/slack'
+import { DateTime } from 'luxon'
+
+export default async (message: any) => {
+  const trackUpdatedMessageData = message.data
+  const shippoTransactionId = trackUpdatedMessageData.transaction
+  const trackingStatus = trackUpdatedMessageData.tracking_status
+  const shipmentEta = trackUpdatedMessageData.eta
+
+  if (shippoTransactionId == null) {
+    throw new Error(`Received Shippo track_updated event without a transaction ID`)
+  }
+
+  const order = await Order.mongo.findOne({ shippoTransactionId })
+  const user = await User.mongo.findById(order.user)
+
+  if (order == null) {
+    throw new Error(`Couldn't find Order with shippoTransactionId: ${shippoTransactionId}`)
+  }
+
+  if (user == null) {
+    throw new Error(`Couldn't find user (${user.id}) for order: ${order.id}`)
+  }
+
+  order.lastShippoTrackingStatus = trackingStatus
+  order.shipmentEta = shipmentEta
+
+  // trackingStatus.status is one of
+  // - PRE_TRANSIT: The label is created but before the package is dropped off or picked up by the carrier.
+  // - TRANSIT: The package has been scanned by the carrier and is in transit.
+  // - DELIVERED: The package has been successfully delivered.
+  // - RETURNED: The package is en route to be returned to the sender, or has been returned successfully.
+  // - FAILURE: The carrier indicated that there has been an issue with the delivery. This can happen for various reasons and depends on the carrier. This status does not indicate a technical, but a delivery issue.
+  // - UNKNOWN: The package has not been found via the carrier’s tracking system.
+  if (trackingStatus.status === 'TRANSIT') {
+    await order.sendShippedEmailIfNeeded({
+      eta: shipmentEta,
+    })
+  } else if (trackingStatus.status === 'DELIVERED') {
+    await order.sendDeliveredEmailIfNeeded()
+  }
+
+  const actionRequired = trackingStatus.action_required
+  const formattedEta = DateTime.fromISO(shipmentEta).toLocaleString(DateTime.DATETIME_MED)
+
+  const slackMessageText = `
+*${actionRequired ? '[ACTION REQUIRED] ' : ''} Order ${order.shortId} for ${formatName(
+    user.name
+  )} shipment tracking update:*
+• Status: ${trackingStatus.status}${trackingStatus.substatus ? `(${trackingStatus.substatus})` : ''}
+• ETA: ${formattedEta}
+  `.trim()
+
+  await Slack.postSimpleMarkdownMessage({ channel: Slack.Channel.Orders, text: slackMessageText })
+}

--- a/server/src/api/shippohooks/index.ts
+++ b/server/src/api/shippohooks/index.ts
@@ -26,7 +26,6 @@ const determineShippohookScenario = (message: any): ShippohookScenario | null =>
 
 shippoWebhooksRouter.post('/', express.json(), async (req, res) => {
   let message = req.body
-  console.log({ message })
   const ShippohookScenario = determineShippohookScenario(message)
   if (ShippohookScenario == null) {
     console.log(

--- a/server/src/api/shippohooks/index.ts
+++ b/server/src/api/shippohooks/index.ts
@@ -1,0 +1,46 @@
+import * as Sentry from '@sentry/node'
+import express from 'express'
+import handleShippoTrackUpdate from './handle-shippo-track-updated'
+
+export enum ShippohookScenario {
+  TrackUpdated,
+}
+
+type ShippohookHandler = (message: any) => Promise<any>
+
+export const shippohookHandlers: Record<ShippohookScenario, ShippohookHandler> = {
+  [ShippohookScenario.TrackUpdated]: handleShippoTrackUpdate,
+}
+
+export const shippoWebhooksRouter = express.Router()
+
+const determineShippohookScenario = (message: any): ShippohookScenario | null => {
+  switch (message.event) {
+    case 'track_updated': {
+      return ShippohookScenario.TrackUpdated
+    }
+    default:
+      return null
+  }
+}
+
+shippoWebhooksRouter.post('/', express.json(), async (req, res) => {
+  let message = req.body
+  console.log({ message })
+  const ShippohookScenario = determineShippohookScenario(message)
+  if (ShippohookScenario == null) {
+    console.log(
+      `Received Shippo webhook for a message type (${message.type}) we don't need: ${message.id}`
+    )
+    return res.status(200).send()
+  }
+
+  const handler = shippohookHandlers[ShippohookScenario]
+  try {
+    await handler(message)
+  } catch (err) {
+    Sentry.captureException(err)
+  }
+
+  return res.status(200).send()
+})

--- a/server/src/api/shippohooks/sample-track-updated-message.json
+++ b/server/src/api/shippohooks/sample-track-updated-message.json
@@ -1,0 +1,109 @@
+{
+  "metadata": "Shippo test webhook",
+  "event": "track_updated",
+  "data": {
+    "test": true,
+    "transaction": null,
+    "tracking_history": [
+      {
+        "location": {
+          "country": "US",
+          "zip": "94103",
+          "state": "CA",
+          "city": "San Francisco"
+        },
+        "substatus": null,
+        "status_date": "2020-03-08T01:29:06.473Z",
+        "status_details": "The carrier has received the electronic shipment information.",
+        "status": "UNKNOWN",
+        "object_id": "7d7dc41675384da5b0b6d17545fb39d2",
+        "object_updated": null,
+        "object_created": "2020-03-12T09:49:06.473Z"
+      },
+      {
+        "location": {
+          "country": "US",
+          "zip": "94103",
+          "state": "CA",
+          "city": "San Francisco"
+        },
+        "substatus": null,
+        "status_date": "2020-03-09T03:34:06.473Z",
+        "status_details": "Your shipment has departed from the origin.",
+        "status": "TRANSIT",
+        "object_id": "8bbc3b13964e4ac2b0a2e8b69297e98a",
+        "object_updated": null,
+        "object_created": "2020-03-12T09:49:06.473Z"
+      },
+      {
+        "location": {
+          "country": "US",
+          "zip": "37501",
+          "state": "TN",
+          "city": "Memphis"
+        },
+        "substatus": null,
+        "status_date": "2020-03-10T05:39:06.473Z",
+        "status_details": "The Postal Service has identified a problem with the processing of this item and you should contact support to get further information.",
+        "status": "FAILURE",
+        "object_id": "334124a6c1fa4e70a94cd60e9b4e35d8",
+        "object_updated": null,
+        "object_created": "2020-03-12T09:49:06.473Z"
+      },
+      {
+        "location": {
+          "country": "US",
+          "zip": "60611",
+          "state": "IL",
+          "city": "Chicago"
+        },
+        "substatus": null,
+        "status_date": "2020-03-11T07:44:06.473Z",
+        "status_details": "Your shipment has been delivered.",
+        "status": "DELIVERED",
+        "object_id": "a2b1d2301c294226ada274784a76cdb1",
+        "object_updated": null,
+        "object_created": "2020-03-12T09:49:06.473Z"
+      }
+    ],
+    "tracking_status": {
+      "location": {
+        "country": "US",
+        "zip": "60611",
+        "state": "IL",
+        "city": "Chicago"
+      },
+      "substatus": null,
+      "status_date": "2020-03-11T07:44:06.471Z",
+      "status_details": "Your shipment has been delivered.",
+      "status": "DELIVERED",
+      "object_id": "2d3d646335e449a8b0308f798970d045",
+      "object_updated": null,
+      "object_created": "2020-03-12T09:49:06.471Z"
+    },
+    "metadata": null,
+    "messages": [],
+    "carrier": null,
+    "tracking_number": "SHIPPO_DELIVERED",
+    "address_from": {
+      "country": "US",
+      "zip": "94103",
+      "state": "CA",
+      "city": "San Francisco"
+    },
+    "address_to": {
+      "country": "US",
+      "zip": "60611",
+      "state": "IL",
+      "city": "Chicago"
+    },
+    "eta": "2020-03-11T09:49:06.459Z",
+    "original_eta": "2020-03-10T09:49:06.459Z",
+    "servicelevel": {
+      "name": null,
+      "token": "shippo_priority"
+    }
+  },
+  "carrier": "shippo",
+  "test": true
+}

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -15,6 +15,7 @@ import { cardRouter } from './api/cardRouter'
 import { contactRouter } from './api/contact'
 import { sendgridRouter } from './api/sendgrid'
 import { stripeWebhooksRouter } from './api/stripehooks'
+import { shippoWebhooksRouter } from 'src/api/shippohooks'
 
 db.init()
 setUpSentry()
@@ -37,5 +38,6 @@ gqlServer.applyMiddleware({ app, path: '/graphql' })
 app.use('/api/sendgrid', cookieMiddleware, bodyParser.json(), sendgridRouter)
 app.use('/api/contact', cookieMiddleware, bodyParser.json(), contactRouter)
 app.use('/api/stripehooks', stripeWebhooksRouter)
+app.use('/api/shippohooks', shippoWebhooksRouter)
 
 app.use('/d', cookieMiddleware, bodyParser.json(), cardRouter)

--- a/server/src/models/Order.ts
+++ b/server/src/models/Order.ts
@@ -13,7 +13,7 @@ import { downloadUrlToFile } from 'src/util/file'
 import { formatName } from 'src/util/name'
 import * as S3 from 'src/util/s3'
 import { createShippoTransaction } from 'src/util/shipment'
-import { postNewOrder, SlackChannel } from 'src/util/slack'
+import { postNewOrder } from 'src/util/slack'
 import { Field, ObjectType } from 'type-graphql'
 import { INITIAL_ORDER_STATE, OrderCreatedBy, OrderEventTrigger, OrderState } from '../util/enums'
 import { BaseModel } from './BaseModel'
@@ -173,7 +173,7 @@ class Order extends BaseModel({
       }
       if (DEPLOY_ENV === 'production') {
         try {
-          await postNewOrder(SlackChannel.Orders, this)
+          await postNewOrder(this)
         } catch (e) {
           console.error(e)
         }

--- a/server/src/models/Order.ts
+++ b/server/src/models/Order.ts
@@ -20,9 +20,8 @@ import { BaseModel } from './BaseModel'
 import { CardVersion } from './CardVersion'
 import OrderEvent from './OrderEvent'
 import { Ref } from './scalars'
-import { Address, OrderPrice } from './subschemas'
+import { Address, OrderPrice, ShippoTrackingStatus } from './subschemas'
 import { User } from './User'
-
 // Mapping of current possible state transitions according to our Order Flow State Machine
 // https://www.notion.so/nomus/Order-Flow-State-Machine-e44affeb35764cc488ac771fa9e28851
 const ALLOWED_STATE_TRANSITIONS: Record<OrderState, Array<OrderState>> = {
@@ -96,10 +95,24 @@ class Order extends BaseModel({
   @Field({ nullable: true })
   trackingNumber?: string
 
+  // Last tracking state received from Shippo
+  @prop({ required: false })
+  lastShippoTrackingStatus?: ShippoTrackingStatus
+
+  // ISO-formatted date string representing when the courier expects to deliver the order
+  @prop({ required: false })
+  shipmentEta?: string
+
   // Object ID for the Shippo Transaction object, if one exists
   // See https://goshippo.com/docs/reference/js#transactions
   @prop({ required: false })
   shippoTransactionId?: string
+
+  @prop({ required: false, default: false })
+  notifiedShipped: boolean
+
+  @prop({ required: false, default: false })
+  notifiedDelivered: boolean
 
   // Stripe PaymentIntent id; may be 1 Intent: n orders
   // ex: One invoice from customer for 12 orders

--- a/server/src/models/Order.ts
+++ b/server/src/models/Order.ts
@@ -10,7 +10,6 @@ import { DEPLOY_ENV } from 'src/config'
 import PrintSpec from 'src/lib/print-spec'
 import { EventualResult, Result } from 'src/util/error'
 import { downloadUrlToFile } from 'src/util/file'
-import { formatName } from 'src/util/name'
 import * as S3 from 'src/util/s3'
 import { createShippoTransaction } from 'src/util/shipment'
 import { postNewOrder } from 'src/util/slack'
@@ -266,6 +265,20 @@ class Order extends BaseModel({
 
     await this.save()
     return this
+  }
+
+  public async sendShippedEmailIfNeeded(this: DocumentType<Order>, data: { eta: string }) {
+    if (this.notifiedShipped) return
+    // TODO
+    this.notifiedShipped = true
+    return this.save()
+  }
+
+  public async sendDeliveredEmailIfNeeded(this: DocumentType<Order>) {
+    if (this.notifiedDelivered) return
+    // TODO
+    this.notifiedDelivered = true
+    return this.save()
   }
 }
 

--- a/server/src/models/subschemas.ts
+++ b/server/src/models/subschemas.ts
@@ -162,3 +162,20 @@ export class TemplateColorScheme {
   @Field({ nullable: true })
   accent4: string | null
 }
+
+// A subset of fields available on https://goshippo.com/docs/reference#tracks
+export class ShippoTrackingStatus {
+  @prop({ required: true })
+  status: string
+
+  @prop({ required: false })
+  substatus: string
+
+  @prop({ required: false })
+  statusDate: Date
+
+  @prop({ required: false })
+  actionRequired: string | null
+
+  // Note: `location` is also available but we don't save/care about it for now
+}

--- a/server/src/util/slack.ts
+++ b/server/src/util/slack.ts
@@ -3,82 +3,117 @@ import { SLACK_BOT_TOKEN } from 'src/config'
 import { CardVersion, Order, User } from 'src/models'
 import { formatDollarAmount } from 'src/util/money'
 
-export enum SlackChannel {
+export enum Channel {
   Orders = 'C02598Y499U',
 }
 
-export const postNewOrder = async (channel: string, order: Order) => {
-  order = await Order.mongo.findById(order.id).populate('cardVersion').populate('user')
+interface SlackMessage {
+  channel: Channel
+  blocks: any[]
+}
+
+interface SlackSimpleMarkdownMessage {
+  channel: Channel
+  text: string
+}
+
+export const postMessage = async ({ channel, blocks }: SlackMessage) => {
   return await axios.post(
     'https://slack.com/api/chat.postMessage',
     {
-      channel: channel,
+      channel,
+      blocks,
+    },
+    { headers: { authorization: `Bearer ${SLACK_BOT_TOKEN}` } }
+  )
+}
+
+export const postSimpleMarkdownMessage = async ({ channel, text }: SlackSimpleMarkdownMessage) => {
+  return await axios.post(
+    'https://slack.com/api/chat.postMessage',
+    {
+      channel,
       blocks: [
         {
-          type: 'header',
+          type: 'section',
           text: {
-            type: 'plain_text',
-            text: `Order ${order.id} in state ${order.state}`,
-            emoji: true,
+            type: 'mrkdwn',
+            text,
           },
-        },
-        {
-          type: 'section',
-          fields: [
-            {
-              type: 'mrkdwn',
-              text: `*Amount: *\n${formatDollarAmount(order.price.total)}`,
-            },
-            { type: 'mrkdwn', text: `*Short ID: *\n${order.shortId}` },
-          ],
-        },
-        {
-          type: 'section',
-          fields: [
-            {
-              type: 'mrkdwn',
-              text: `*Shipping Address:*
-Line 1: ${order.shippingAddress.line1}
-Line 2: ${order.shippingAddress.line2}
-City: ${order.shippingAddress.city}
-State: ${order.shippingAddress.state}
-Postal Code: ${order.shippingAddress.postalCode}`,
-            },
-            {
-              type: 'mrkdwn',
-              text: `*Name*:\n${(order.user as User).name.first} ${
-                (order.user as User).name.middle ? (order.user as User).name.middle : ''
-              } ${(order.user as User).name.last}\n 
-*Quantity*:\n${order.quantity}`,
-            },
-          ],
-        },
-        {
-          type: 'image',
-          title: {
-            type: 'plain_text',
-            text: 'Card Front',
-            emoji: true,
-          },
-          // eslint-disable-next-line camelcase
-          image_url: `${(order.cardVersion as CardVersion).frontImageUrl}`,
-          // eslint-disable-next-line camelcase
-          alt_text: 'Card Front',
-        },
-        {
-          type: 'image',
-          title: {
-            type: 'plain_text',
-            text: 'Card Back',
-            emoji: true,
-          },
-          // eslint-disable-next-line camelcase
-          image_url: `${(order.cardVersion as CardVersion).backImageUrl}`,
-          // eslint-disable-next-line camelcase
-          alt_text: 'Card Back',
         },
       ],
     },
     { headers: { authorization: `Bearer ${SLACK_BOT_TOKEN}` } }
   )
+}
+
+export const postNewOrder = async (order: Order) => {
+  await postMessage({
+    channel: Channel.Orders,
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: `Order ${order.id} in state ${order.state}`,
+          emoji: true,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*Amount: *\n${formatDollarAmount(order.price.total)}`,
+          },
+          { type: 'mrkdwn', text: `*Short ID: *\n${order.shortId}` },
+        ],
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*Shipping Address:*
+Line 1: ${order.shippingAddress.line1}
+Line 2: ${order.shippingAddress.line2}
+City: ${order.shippingAddress.city}
+State: ${order.shippingAddress.state}
+Postal Code: ${order.shippingAddress.postalCode}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Name*:\n${(order.user as User).name.first} ${
+              (order.user as User).name.middle ? (order.user as User).name.middle : ''
+            } ${(order.user as User).name.last}\n 
+*Quantity*:\n${order.quantity}`,
+          },
+        ],
+      },
+      {
+        type: 'image',
+        title: {
+          type: 'plain_text',
+          text: 'Card Front',
+          emoji: true,
+        },
+        // eslint-disable-next-line camelcase
+        image_url: `${(order.cardVersion as CardVersion).frontImageUrl}`,
+        // eslint-disable-next-line camelcase
+        alt_text: 'Card Front',
+      },
+      {
+        type: 'image',
+        title: {
+          type: 'plain_text',
+          text: 'Card Back',
+          emoji: true,
+        },
+        // eslint-disable-next-line camelcase
+        image_url: `${(order.cardVersion as CardVersion).backImageUrl}`,
+        // eslint-disable-next-line camelcase
+        alt_text: 'Card Back',
+      },
+    ],
+  })
 }


### PR DESCRIPTION
## Summary

Creates a webhook handler to run whenever Shippo fires us [a `track_updated` event](https://goshippo.com/docs/tracking/#event-definitions) which does the following:
* updates some key properties on the associated `Order` object: 
  * `lastShippoTrackingStatus` (an object that includes a few subfields of info)
  * `shipmentEta`
* sends the user a shipped or delivered email if we haven't already for this order
  * NOTE: the underlying methods for sending the email don't do anything yet (will add in separate PR(s))
* sends a message to our Slack #orders channel with the shipping update so we have visibility

<!-- Link to the relevant task in Notion here -->
## Notion task

https://www.notion.so/nomus/Create-webhook-handler-for-Shippo-s-track_updated-event-1213bf4f61b64086a3218c9db577e78d